### PR TITLE
Improve filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 
 ## v0.9 ( 2023-??-?? )
 
+* New option `-l/--print-seq` to print the result immediately (default is
+  to print a summary)
 * Improve filtering
-   * New option `--match-all` to run all tests that match ALL keywords instead
-     of the ones matching ANY keyword
+   * New option `-A/--match-all` to run all tests that match ALL keywords
+     instead of the ones matching ANY keyword
    * Add words of the test name to the test keywords
    * Remove comment date during promotion, remove corresponding option --no-comment
    * Transform all keywords to lowercase to match in a case-insensitive manner

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,15 @@
 
 ## v0.9 ( 2023-??-?? )
 
+* Improve filtering
+   * New option `--match-all` to run all tests that match ALL keywords instead
+     of the ones matching ANY keyword
+   * Add words of the test name to the test keywords
+   * Remove comment date during promotion, remove corresponding option --no-comment
+   * Transform all keywords to lowercase to match in a case-insensitive manner
+* Add some spaces between arguments during promotion
 * Support for exit code 99: fail the entire AT_CHECK without running
-  run-if-fail
+  run-if-fail actions
 
 ## v0.8 ( 2023-03-15 )
 

--- a/src/autofonce_core/parser.ml
+++ b/src/autofonce_core/parser.ml
@@ -183,6 +183,17 @@ let load_file ~dirs ~keep_files ~path c filename =
               in
               let macros, actions = iter_actions t steps [] macros in
               t.test_actions <- before @ actions ;
+              let test_name = String.map (fun c ->
+                  match c with
+                  | 'a'..'z'
+                  | 'A'..'Z'
+                  | '-'
+                  | '0'..'9' -> c
+                  | _ -> ' ') t.test_name
+              in
+              t.test_keywords <- t.test_keywords
+                                 @ EzString.split_simplify test_name ' ';
+              t.test_keywords <- List.map String.lowercase_ascii t.test_keywords ;
               iter_state s macros
 
           | Macro (_, _) ->

--- a/src/autofonce_lib/command_promote.ml
+++ b/src/autofonce_lib/command_promote.ml
@@ -22,7 +22,6 @@ open Globals
 (* TODO: check why the ignore pattern does not work *)
 let diff = Patch_lines.Diff { exclude = [ "^# promoted on .*" ]}
 let todo = ref diff
-let comment = ref true
 let not_exit = ref false
 
 let promote p tc suite =
@@ -30,6 +29,7 @@ let promote p tc suite =
   Patch_lines.reset ();
   let state = Runner_common.create_state p tc suite in
   Unix.chdir state.state_run_dir ;
+  (*
   let comment_line =
     let t = Unix.gettimeofday () in
     let tm = Unix.localtime t in
@@ -40,6 +40,7 @@ let promote p tc suite =
       tm.tm_hour
       tm.tm_min
   in
+*)
   let promote_test t =
     let file = t.test_loc.file in
     Printf.eprintf "Promoting test %d %s\n%!"
@@ -55,9 +56,6 @@ let promote p tc suite =
     let b = Buffer.create 10000 in
 
     Printf.bprintf b "AT_SETUP(%s)\n" (Parser.m4_escape t.test_name);
-
-    if !comment then
-      Printf.bprintf b "%s\n" comment_line;
 
     begin
       match t.test_keywords with
@@ -80,10 +78,6 @@ let promote p tc suite =
   ()
 
 let args auto_promote_arg = [
-
-  [ "no-comment" ], Arg.Clear comment,
-  EZCMD.info ~env:(EZCMD.env "AUTOFONCE_PROMOTE_NO_COMMENT")
-    "Do not add a comment with the promotion date";
 
   [ "not-exit" ], Arg.Set not_exit,
   EZCMD.info "Do not promote exit code" ;

--- a/src/autofonce_lib/command_run.ml
+++ b/src/autofonce_lib/command_run.ml
@@ -28,6 +28,16 @@ let cmd =
       [ "e" ; "stop-on-failure" ], Arg.Set stop_on_first_failure,
       EZCMD.info "Stop on first failure";
 
+      [ "j" ], Arg.Int (fun n -> max_jobs := max 1 n),
+      EZCMD.info ~docv:"NJOBS" "Set maximal parallelism";
+
+      [ "1" ; "j1" ], Arg.Unit (fun () -> max_jobs := 1),
+      EZCMD.info "Use Sequential scheduling of tests";
+
+      [ "l" ; "print-seq" ], Arg.Set Runner_common.print_results,
+      EZCMD.info
+        "Print results immediately (default is to print a summary at the end)";
+
       [ "s" ; "keep-more" ], Arg.Set keep_skipped,
       EZCMD.info "Keep directories of skipped and expected failed";
 
@@ -37,11 +47,9 @@ let cmd =
       [ "no-clean" ], Arg.Clear clean_tests_dir,
       EZCMD.info "Do not clean _autofonce/ dir on startup";
 
-      [ "j1" ], Arg.Unit (fun () -> max_jobs := 1),
-      EZCMD.info "Use Sequential scheduling of tests";
-
-      [ "j" ], Arg.Int (fun n -> max_jobs := max 1 n),
-      EZCMD.info ~docv:"NJOBS" "Set maximal parallelism";
+      [ "diff" ], Arg.Unit (fun () ->
+          Globals.auto_promote := 1),
+      EZCMD.info "Print a diff showing what would be promoted";
 
     ]
   in

--- a/src/autofonce_lib/filter.ml
+++ b/src/autofonce_lib/filter.ml
@@ -76,7 +76,8 @@ let select_tests ?state select_test suite =
           || id_set. (t.test_id)
           ||
           (if !all_keywords then
-             List.for_all (fun k ->  StringSet.mem k keyword_set) t.test_keywords
+             StringSet.for_all
+               (fun k ->  List.mem k t.test_keywords) keyword_set
            else
              List.exists (fun k ->  StringSet.mem k keyword_set) t.test_keywords)
          )
@@ -177,13 +178,13 @@ let args = [
     ),
   EZCMD.info ~docv:"ID" "Run only test ID";
 
-  [ "after" ], Arg.Int (fun x ->
+  [ "ge" ; "after" ], Arg.Int (fun x ->
       exec_after := x;
       clean_tests_dir := false;
     ),
   EZCMD.info ~docv:"ID" "Exec starting at test $(docv)";
 
-  [ "before" ], Arg.Int (fun x ->
+  [ "le" ; "before" ], Arg.Int (fun x ->
       exec_before := x;
       clean_tests_dir := false;
     ),
@@ -203,13 +204,13 @@ let args = [
     ),
   EZCMD.info ~docv:"REASON" "Run failed tests with given failure";
 
-  [ "failed" ], Arg.Unit (fun () ->
+  [ "F"; "failed" ], Arg.Unit (fun () ->
       only_failed := true ;
       clean_tests_dir := false
     ),
   EZCMD.info "Run only previously failed tests (among selected tests)";
 
-  [ "match-all" ], Arg.Set all_keywords,
+  [ "A" ; "match-all" ], Arg.Set all_keywords,
   EZCMD.info "Run tests matching all keywords instead of only one";
 
   [], Arg.Anons (fun list ->

--- a/src/autofonce_lib/promote.ml
+++ b/src/autofonce_lib/promote.ml
@@ -153,7 +153,7 @@ let print_actions ~not_exit ~keep_old b actions =
     match action with
     | AT_CLEANUP _ -> Printf.bprintf b "AT_CLEANUP";
     | AT_DATA { file ; content } ->
-        Printf.bprintf b "AT_DATA(%s,%s)\n"
+        Printf.bprintf b "AT_DATA(%s, %s)\n"
           ( Parser.m4_escape file )
           ( Parser.m4_escape content )
     | AF_ENV string ->
@@ -178,7 +178,7 @@ let print_actions ~not_exit ~keep_old b actions =
         if promote then
           Printf.bprintf b "AF_%s([%s])\n"
             (if copy then "COPY" else "LINK")
-            ( String.concat "],["
+            ( String.concat "], ["
                 ( List.map Parser.m4_escape files ))
     | AT_CHECK  check ->
         Buffer.add_string b "AT_CHECK(";

--- a/src/autofonce_lib/runner_common.ml
+++ b/src/autofonce_lib/runner_common.ml
@@ -21,6 +21,8 @@ module PARSER = Autofonce_core.Parser
 module MISC = Autofonce_misc.Misc
 module CONFIG = Autofonce_config.Project_config
 
+let print_results = ref false
+
 let status_len = 30
 let spaces = String.make 80 ' '
 
@@ -44,6 +46,14 @@ let test_status ter fmt =
     ) fmt
 
 let buffer_test state test_status =
+  if !print_results then begin
+    if Terminal.isatty then begin
+      Terminal.move_bol ();
+      Terminal.erase Eol;
+      Terminal.printf [] "%s\n" test_status
+    end else
+      Printf.eprintf "%s\n" test_status ;
+  end ;
   Printf.bprintf state.state_buffer "%s\n" test_status
 
 let commented s =


### PR DESCRIPTION
* New option `--match-all` to run all tests that match ALL keywords instead of the ones matching ANY keyword
* Add words of the test name to the test keywords
* Remove comment date during promotion, remove corresponding option --no-comment
* Transform all keywords to lowercase to match in a case-insensitive manner