### PR TITLE
Improve subcommand names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@
   * add support for [stdout], [stderr], [expout] and [experr]
 * Add file basename to test keywords, so that it is possible to use it
 as a keyword to select all the test of a file
-* Add --diff-args="..." to use instead of "-u" during promotion display
+* Rename subcommands to reduce confusion: [promote] now corresponds to the 
+old [run --auto-promote=n] and the old promote is renamed into [diff].
+* Add --diff-args="..." to use instead of "-u" during diff display
 
 ## v0.9 ( 2023-06-27 )
 

--- a/sphinx/commands.rst
+++ b/sphinx/commands.rst
@@ -13,6 +13,9 @@ Overview of sub-commands::
   config
     Print config of the current project
   
+  diff
+    Display difference between tests results and expected results
+  
   init
     Initialize project to run the testsuite with autofonce
   
@@ -44,34 +47,89 @@ List the tests, with their numeric identifier, their name and their location in 
 **USAGE**
 ::
   
-  autofonce config ID [OPTIONS]
+  autofonce config [OPTIONS]
+
+Where options are:
+
+
+* :code:`-E TESTSUITE.sh` or :code:`--env TESTSUITE.sh`   Env file for all tests
+
+* :code:`-I DIR`   Add DIR to search path for tests
+
+* :code:`-T TESTSUITE.at` or :code:`--at TESTSUITE.at`   Path of the file containing the testsuite
+
+* :code:`-t TESTSUITE` or :code:`--testsuite TESTSUITE`   Name of the testsuite to run (as specified in 'autofonce.toml')
+
+
+autofonce diff
+~~~~~~~~~~~~~~~~
+
+Display difference between tests results and expected results
+
+
+
+**DESCRIPTION**
+
+
+After an unsucessful testsuite run, use this command to showthe differences between the test results and the expected results.
+
+**USAGE**
+::
+  
+  autofonce diff ID [OPTIONS]
 
 Where options are:
 
 
 * :code:`ID`   Exec ending at test ID
 
+* :code:`-1` or :code:`--j1`   Use Sequential scheduling of tests
+
+* :code:`-A` or :code:`--match-all`   Run tests matching all keywords instead of only one
+
 * :code:`-E TESTSUITE.sh` or :code:`--env TESTSUITE.sh`   Env file for all tests
+
+* :code:`-F` or :code:`--failed`   Run only previously failed tests (among selected tests)
 
 * :code:`-I DIR`   Add DIR to search path for tests
 
 * :code:`-N KEYWORD` or :code:`--not KEYWORD`   Skip tests matching KEYWORD
 
+* :code:`-S` or :code:`--keep-all`   Keep all directories of tests
+
 * :code:`-T TESTSUITE.at` or :code:`--at TESTSUITE.at`   Path of the file containing the testsuite
 
-* :code:`--after ID`   Exec starting at test ID
+* :code:`--apply`   Apply the generated diff promoting the test results once
 
-* :code:`--before ID`   Exec ending at test ID
+* :code:`--diff-args ARGS`   Pass these args to the diff command
 
-* :code:`--failed`   Run only previously failed tests (among selected tests)
+* :code:`-e` or :code:`--stop-on-failure`   Stop on first failure
 
 * :code:`--failures REASON`   Run failed tests with given failure
 
+* :code:`--fake-apply .EXT`   Apply the diff to create new files with extension .EXT
+
+* :code:`--ge ID` or :code:`--after ID`   Exec starting at test ID
+
 * :code:`-i ID` or :code:`--ids ID`   Run only test ID
+
+* :code:`--ignore-exitcode`   Do not promote or fail for wrong exit code
+
+* :code:`-j NJOBS`   Set maximal parallelism
 
 * :code:`-k KEYWORD` or :code:`--keywords KEYWORD`   Run only tests matching KEYWORD
 
+* :code:`-l` or :code:`--print-seq`   Print results immediately (default is to print a summary at the end)
+
+* :code:`--le ID` or :code:`--before ID`   Exec ending at test ID
+
+* :code:`--no-clean`   Do not clean _autofonce/ dir on startup
+
 * :code:`-o TESTSUITE` or :code:`--output TESTSUITE`   Path of the output file (default: _autofonce/results.log)
+
+* :code:`--print-all`   Print also expected failures
+
+* :code:`-s` or :code:`--keep-more`   Keep directories of skipped and expected failed
 
 * :code:`-t TESTSUITE` or :code:`--testsuite TESTSUITE`   Name of the testsuite to run (as specified in 'autofonce.toml')
 
@@ -152,7 +210,11 @@ Where options are:
 
 * :code:`ID`   Exec ending at test ID
 
+* :code:`-A` or :code:`--match-all`   Run tests matching all keywords instead of only one
+
 * :code:`-E TESTSUITE.sh` or :code:`--env TESTSUITE.sh`   Env file for all tests
+
+* :code:`-F` or :code:`--failed`   Run only previously failed tests (among selected tests)
 
 * :code:`-I DIR`   Add DIR to search path for tests
 
@@ -160,19 +222,15 @@ Where options are:
 
 * :code:`-T TESTSUITE.at` or :code:`--at TESTSUITE.at`   Path of the file containing the testsuite
 
-* :code:`--after ID`   Exec starting at test ID
-
-* :code:`--before ID`   Exec ending at test ID
-
-* :code:`--failed`   Run only previously failed tests (among selected tests)
-
 * :code:`--failures REASON`   Run failed tests with given failure
+
+* :code:`--ge ID` or :code:`--after ID`   Exec starting at test ID
 
 * :code:`-i ID` or :code:`--ids ID`   Run only test ID
 
 * :code:`-k KEYWORD` or :code:`--keywords KEYWORD`   Run only tests matching KEYWORD
 
-* :code:`-o TESTSUITE` or :code:`--output TESTSUITE`   Path of the output file (default: _autofonce/results.log)
+* :code:`--le ID` or :code:`--before ID`   Exec ending at test ID
 
 * :code:`-t TESTSUITE` or :code:`--testsuite TESTSUITE`   Name of the testsuite to run (as specified in 'autofonce.toml')
 
@@ -221,7 +279,7 @@ Promote tests results as expected results
 **DESCRIPTION**
 
 
-After an unsucessful testsuite run, use this command to promote the results of tests to expected status.
+Use this command to promote the results of tests to expected results.This command runs and promote failing tests several times if needed.
 
 **USAGE**
 ::
@@ -233,39 +291,49 @@ Where options are:
 
 * :code:`ID`   Exec ending at test ID
 
+* :code:`-1` or :code:`--j1`   Use Sequential scheduling of tests
+
+* :code:`-A` or :code:`--match-all`   Run tests matching all keywords instead of only one
+
 * :code:`-E TESTSUITE.sh` or :code:`--env TESTSUITE.sh`   Env file for all tests
+
+* :code:`-F` or :code:`--failed`   Run only previously failed tests (among selected tests)
 
 * :code:`-I DIR`   Add DIR to search path for tests
 
 * :code:`-N KEYWORD` or :code:`--not KEYWORD`   Skip tests matching KEYWORD
 
+* :code:`-S` or :code:`--keep-all`   Keep all directories of tests
+
 * :code:`-T TESTSUITE.at` or :code:`--at TESTSUITE.at`   Path of the file containing the testsuite
 
-* :code:`--after ID`   Exec starting at test ID
-
-* :code:`--apply`   Apply promotion (default is to diff)
-
-* :code:`--auto-run INT`   Promote and run until all tests have been promoted
-
-* :code:`--before ID`   Exec ending at test ID
-
-* :code:`--diff`   Diff promotion (default)
-
-* :code:`--failed`   Run only previously failed tests (among selected tests)
+* :code:`-e` or :code:`--stop-on-failure`   Stop on first failure
 
 * :code:`--failures REASON`   Run failed tests with given failure
 
-* :code:`--fake .EXT`   Apply promotion to create new files with extension .EXT
+* :code:`--ge ID` or :code:`--after ID`   Exec starting at test ID
 
 * :code:`-i ID` or :code:`--ids ID`   Run only test ID
 
+* :code:`--ignore-exitcode`   Do not promote or fail for wrong exit code
+
+* :code:`-j NJOBS`   Set maximal parallelism
+
 * :code:`-k KEYWORD` or :code:`--keywords KEYWORD`   Run only tests matching KEYWORD
 
-* :code:`--no-comment`   Do not add a comment with the promotion date
+* :code:`-l` or :code:`--print-seq`   Print results immediately (default is to print a summary at the end)
 
-* :code:`--not-exit`   Do not promote exit code
+* :code:`--le ID` or :code:`--before ID`   Exec ending at test ID
+
+* :code:`-n n` or :code:`--nb-promotions n`   Maximum number of result promotions before failing (10 by default)
+
+* :code:`--no-clean`   Do not clean _autofonce/ dir on startup
 
 * :code:`-o TESTSUITE` or :code:`--output TESTSUITE`   Path of the output file (default: _autofonce/results.log)
+
+* :code:`--print-all`   Print also expected failures
+
+* :code:`-s` or :code:`--keep-more`   Keep directories of skipped and expected failed
 
 * :code:`-t TESTSUITE` or :code:`--testsuite TESTSUITE`   Name of the testsuite to run (as specified in 'autofonce.toml')
 
@@ -314,7 +382,13 @@ Where options are:
 
 * :code:`ID`   Exec ending at test ID
 
+* :code:`-1` or :code:`--j1`   Use Sequential scheduling of tests
+
+* :code:`-A` or :code:`--match-all`   Run tests matching all keywords instead of only one
+
 * :code:`-E TESTSUITE.sh` or :code:`--env TESTSUITE.sh`   Env file for all tests
+
+* :code:`-F` or :code:`--failed`   Run only previously failed tests (among selected tests)
 
 * :code:`-I DIR`   Add DIR to search path for tests
 
@@ -324,31 +398,25 @@ Where options are:
 
 * :code:`-T TESTSUITE.at` or :code:`--at TESTSUITE.at`   Path of the file containing the testsuite
 
-* :code:`--after ID`   Exec starting at test ID
-
-* :code:`--auto-promote INT`   Promote and run until all tests have been promoted
-
-* :code:`--before ID`   Exec ending at test ID
-
 * :code:`-e` or :code:`--stop-on-failure`   Stop on first failure
-
-* :code:`--failed`   Run only previously failed tests (among selected tests)
 
 * :code:`--failures REASON`   Run failed tests with given failure
 
+* :code:`--ge ID` or :code:`--after ID`   Exec starting at test ID
+
 * :code:`-i ID` or :code:`--ids ID`   Run only test ID
+
+* :code:`--ignore-exitcode`   Do not promote or fail for wrong exit code
 
 * :code:`-j NJOBS`   Set maximal parallelism
 
-* :code:`--j1`   Use Sequential scheduling of tests
-
 * :code:`-k KEYWORD` or :code:`--keywords KEYWORD`   Run only tests matching KEYWORD
 
+* :code:`-l` or :code:`--print-seq`   Print results immediately (default is to print a summary at the end)
+
+* :code:`--le ID` or :code:`--before ID`   Exec ending at test ID
+
 * :code:`--no-clean`   Do not clean _autofonce/ dir on startup
-
-* :code:`--no-comment`   Do not add a comment with the promotion date
-
-* :code:`--not-exit`   Do not promote exit code
 
 * :code:`-o TESTSUITE` or :code:`--output TESTSUITE`   Path of the output file (default: _autofonce/results.log)
 

--- a/src/autofonce_lib/command_diff.ml
+++ b/src/autofonce_lib/command_diff.ml
@@ -19,11 +19,11 @@ module Misc = Autofonce_misc.Misc
 open Types
 open Filter
 
+
 (* TODO: check why the ignore pattern does not work *)
 let diff args = Patch_lines.Diff { exclude = [ "^# promoted on .*" ]; args }
 let todo = ref (diff None)
 
-(* TODO: remove code duplication with Command_diff *)
 let patch_action ~filter_args ~exec_args ~action p tc suite =
   filter_args.arg_only_failed <- true ;
   Patch_lines.reset ();
@@ -42,50 +42,41 @@ let patch_action ~filter_args ~exec_args ~action p tc suite =
   in
 *)
   let promote_test t =
-
-    let rec check actions =
-      match actions with
-      | [] -> false
-      | AF_COMMENT comment ::
-        AT_DATA _ ::
-        _ when EzString.starts_with comment ~prefix:"autofonce.read:"
-        -> true
-      | _ :: actions -> check actions
+    let file = t.test_loc.file in
+    Printf.eprintf "Promoting test %d %s\n%!"
+      t.test_id ( Parser.name_of_loc t.test_loc );
+    let line_first = t.test_loc.line in
+    let line_last =
+      match List.rev t.test_actions with
+      | AT_CLEANUP { loc } :: _ -> loc.line
+      | _ -> Misc.error
+               "Last test in %s does not end with AT_CLEANUP ?" file
     in
-    if check t.test_actions then
-      let file = t.test_loc.file in
-      Printf.eprintf "Promoting test %d %s\n%!"
-        t.test_id ( Parser.name_of_loc t.test_loc );
-      let line_first = t.test_loc.line in
-      let line_last =
-        match List.rev t.test_actions with
-        | AT_CLEANUP { loc } :: _ -> loc.line
-        | _ -> Misc.error
-                 "Last test in %s does not end with AT_CLEANUP ?" file
-      in
 
-      let b = Buffer.create 10000 in
+    let b = Buffer.create 10000 in
 
-      Printf.bprintf b "AT_SETUP(%s)\n" (Parser.m4_escape t.test_name);
+    Printf.bprintf b "AT_SETUP(%s)\n" (Parser.m4_escape t.test_name);
 
-      begin
-        match t.test_keywords with
-        | [] -> ()
-        | list ->
-            Printf.bprintf b "AT_KEYWORDS(%s)\n\n"
-              (Parser.m4_escape (String.concat " " list))
-      end;
-      Promote.print_actions
-        ~ignore_exitcode:exec_args.arg_ignore_exitcode
-        ~keep_old:true
-        t b t.test_actions;
+    begin
+      match t.test_keywords with
+      | [] -> ()
+      | list ->
+          Printf.bprintf b "AT_KEYWORDS(%s)\n\n"
+            (Parser.m4_escape (String.concat " " list))
+    end;
+    Promote.print_actions
+      ~ignore_exitcode:exec_args.arg_ignore_exitcode
+      ~keep_old:false
+      t b t.test_actions;
 
-      let content = Buffer.contents b in
-      Patch_lines.replace_block ~file ~line_first ~line_last content
+    let content = Buffer.contents b in
+    Patch_lines.replace_block ~file ~line_first ~line_last content
   in
-  List.iter promote_test suite.suite_tests;
+  Filter.select_tests ~args:filter_args ~state promote_test suite;
+
   Patch_lines.commit_to_disk ~action ();
   ()
+
 
 
 let cmd =
@@ -111,17 +102,18 @@ let cmd =
     ]
   in
   EZCMD.sub
-    "regen"
+    "diff"
     (fun () ->
        let filter_args = get_filter_args () in
        let p, tc, suite = Testsuite.find ( get_testsuite_args () ) in
        patch_action ~filter_args ~exec_args ~action:!todo p tc suite
     )
     ~args
-    ~doc: "Regenerate tests from templates"
+    ~doc: "Display difference between tests results and expected results"
     ~man:[
       `S "DESCRIPTION";
       `Blocks [
-        `P {|.|} ;
+        `P "After an unsucessful testsuite run, use this command to show\
+           the differences between the test results and the expected results." ;
       ];
     ]

--- a/src/autofonce_lib/command_gen.ml
+++ b/src/autofonce_lib/command_gen.ml
@@ -165,7 +165,7 @@ let cmd =
        Command_regen.regen ();
        Printf.eprintf "1. Use `autofonce init` to initialize autofonce.toml file\n";
        Printf.eprintf "2. Use `autofonce run` to run the generated tests afterwards.\n";
-       Printf.eprintf "3. Fix the tests and run `autofonce run --auto-promote 2` to run and promote tests.\n";
+       Printf.eprintf "3. Fix the tests and run `autofonce promote` to run and promote tests.\n";
     )
     ~args
     ~doc: "Generate a testsuite"

--- a/src/autofonce_lib/command_promote.ml
+++ b/src/autofonce_lib/command_promote.ml
@@ -12,98 +12,22 @@
 
 open Ezcmd.V2
 open EZCMD.TYPES
-
 module Patch_lines = Autofonce_patch.Patch_lines
-module Parser = Autofonce_core.Parser
-module Misc = Autofonce_misc.Misc
-open Types
-open Filter
 
-(* TODO: check why the ignore pattern does not work *)
-let diff args = Patch_lines.Diff { exclude = [ "^# promoted on .*" ]; args }
-let todo = ref (diff None)
-let not_exit = ref false
-
-let promote ~filter_args ~exec_args p tc suite =
-  filter_args.arg_only_failed <- true ;
-  Patch_lines.reset ();
-  let state = Runner_common.create_state ~exec_args p tc suite in
-  Unix.chdir state.state_run_dir ;
-  (*
-  let comment_line =
-    let t = Unix.gettimeofday () in
-    let tm = Unix.localtime t in
-    Printf.sprintf "# promoted on %04d-%02d-%02dT%02d:%02d"
-      ( 1900 + tm.tm_year )
-      ( 1 + tm.tm_mon )
-      tm.tm_mday
-      tm.tm_hour
-      tm.tm_min
-  in
-*)
-  let promote_test t =
-    let file = t.test_loc.file in
-    Printf.eprintf "Promoting test %d %s\n%!"
-      t.test_id ( Parser.name_of_loc t.test_loc );
-    let line_first = t.test_loc.line in
-    let line_last =
-      match List.rev t.test_actions with
-      | AT_CLEANUP { loc } :: _ -> loc.line
-      | _ -> Misc.error
-               "Last test in %s does not end with AT_CLEANUP ?" file
-    in
-
-    let b = Buffer.create 10000 in
-
-    Printf.bprintf b "AT_SETUP(%s)\n" (Parser.m4_escape t.test_name);
-
-    begin
-      match t.test_keywords with
-      | [] -> ()
-      | list ->
-          Printf.bprintf b "AT_KEYWORDS(%s)\n\n"
-            (Parser.m4_escape (String.concat " " list))
-    end;
-    Promote.print_actions
-      ~not_exit:!not_exit
-      ~keep_old:false
-      t b t.test_actions;
-
-    let content = Buffer.contents b in
-    Patch_lines.replace_block ~file ~line_first ~line_last content
-  in
-  Filter.select_tests ~args:filter_args ~state promote_test suite;
-
-  Patch_lines.commit_to_disk ~action:!todo ();
-  ()
-
-let args auto_promote_arg ~exec_args = [
-
-  [ "not-exit" ], Arg.Set not_exit,
-  EZCMD.info "Do not promote exit code" ;
-
-  [ "diff-args" ], Arg.String (fun s -> todo := diff (Some s)),
-  EZCMD.info ~docv:"ARGS" "Pass these args to the diff command" ;
-
-  [ auto_promote_arg ], Arg.Int (fun n ->
-      exec_args.arg_auto_promote <- n ;
-      todo := Apply ;
-    ),
-  EZCMD.info
-    "Promote and run until all tests have been promoted"
-
-]
+let nb_promotions = ref 10
 
 let rec action ~filter_args ~exec_args p tc suite =
-  promote ~filter_args ~exec_args p tc suite ;
-  if exec_args.arg_auto_promote > 0 then begin
-    filter_args.arg_only_failed <- true ;
-    filter_args.arg_filter <- true ;
-    let n = Testsuite.exec ~filter_args ~exec_args p tc suite in
-    exec_args.arg_auto_promote <- exec_args.arg_auto_promote - 1;
-    if n>0 then
+  let n = Testsuite.exec ~filter_args ~exec_args p tc suite in
+  if n > 0 then begin
+    if !nb_promotions > 0 then begin
+      decr nb_promotions;
+      filter_args.arg_only_failed <- true ;
+      filter_args.arg_filter <- true ;
+      Command_diff.patch_action ~filter_args ~exec_args ~action:Patch_lines.Apply p tc suite ;
       let (p, tc, suite) = Testsuite.read p tc in
       action ~filter_args ~exec_args p tc suite
+    end else
+      exit 1
   end
 
 let cmd =
@@ -114,18 +38,10 @@ let cmd =
     runner_args @
     testsuite_args @
     filter_args @
-    args ~exec_args "auto-run" @
     [
 
-      [ "apply" ], Arg.Unit (fun () -> todo := Apply),
-      EZCMD.info "Apply promotion (default is to diff)" ;
-
-      [ "diff" ], Arg.Unit (fun () -> todo := diff None),
-      EZCMD.info "Diff promotion (default)" ;
-
-      [ "fake" ], Arg.String (fun ext -> todo := Fake ext),
-      EZCMD.info ~docv:".EXT"
-        "Apply promotion to create new files with extension $(docv)" ;
+      [ "n" ; "nb-promotions" ], Arg.Set_int nb_promotions, 
+      EZCMD.info ~docv:"n" "Maximum number of result promotions before failing (10 by default)" ;
 
     ]
   in
@@ -141,6 +57,7 @@ let cmd =
     ~man:[
       `S "DESCRIPTION";
       `Blocks [
-        `P {|After an unsucessful testsuite run, use this command to promote the results of tests to expected status.|} ;
+        `P "Use this command to promote the results of tests to expected results.\
+            This command runs and promote failing tests several times if needed." ;
       ];
     ]

--- a/src/autofonce_lib/command_run.ml
+++ b/src/autofonce_lib/command_run.ml
@@ -20,12 +20,7 @@ let cmd =
   let args =
     runner_args @
     testsuite_args @
-    filter_args @
-    Command_promote.args ~exec_args "auto-promote" @
-    [
-
-
-    ]
+    filter_args
   in
   EZCMD.sub
     "run"
@@ -34,10 +29,7 @@ let cmd =
          let filter_args = get_filter_args () in
          let (p, tc, suite) = Testsuite.find ( get_testsuite_args () ) in
          let n = Testsuite.exec ~filter_args ~exec_args p tc suite in
-         if n>0 && exec_args.arg_auto_promote > 0 then
-           Command_promote.action ~filter_args ~exec_args p tc suite
-         else
-         if n>0 then exit 1
+         if n > 0 then exit 1
        with
          exn ->
            if Printexc.backtrace_status () then

--- a/src/autofonce_lib/logging.ml
+++ b/src/autofonce_lib/logging.ml
@@ -185,7 +185,7 @@ let log_failed_tests state msg tests =
 
       Buffer.reset b1;
       Promote.print_actions
-        ~not_exit:false
+        ~ignore_exitcode:false
         ~keep_old:true
         t b1 t.test_actions ;
       let s1 = Buffer.contents b1 in
@@ -194,7 +194,7 @@ let log_failed_tests state msg tests =
 
       Buffer.reset b2;
       Promote.print_actions
-        ~not_exit:false
+        ~ignore_exitcode:false
         ~keep_old:false
         t b2 t.test_actions ;
       let s2 = Buffer.contents b2 in

--- a/src/autofonce_lib/main.ml
+++ b/src/autofonce_lib/main.ml
@@ -44,6 +44,7 @@ let commands = [
   Command_run.cmd ;
   Command_new.cmd ;
   Command_regen.cmd ;
+  Command_diff.cmd ;
   Command_promote.cmd ;
 ]
 

--- a/src/autofonce_lib/promote.ml
+++ b/src/autofonce_lib/promote.ml
@@ -29,7 +29,7 @@ open Types
 *)
 
 
-let print_actions t ~not_exit ~keep_old b actions =
+let print_actions t ~ignore_exitcode ~keep_old b actions =
   let rec string_of_check check =
     let b = Buffer.create 1000 in
     Buffer.add_string b "AT_CHECK(";
@@ -47,7 +47,7 @@ let print_actions t ~not_exit ~keep_old b actions =
       (* We can promote these results *)
 
       let retcode =
-        if not_exit || keep_old then check.check_retcode
+        if ignore_exitcode || keep_old then check.check_retcode
         else
           match check.check_retcode with
           | None -> None

--- a/src/autofonce_lib/promote.mli
+++ b/src/autofonce_lib/promote.mli
@@ -12,6 +12,6 @@
 
 val print_actions :
   Types.test ->
-  not_exit:bool ->
+  ignore_exitcode:bool ->
   keep_old:bool ->
   Buffer.t -> Types.action list -> unit

--- a/src/autofonce_lib/runner_common.ml
+++ b/src/autofonce_lib/runner_common.ml
@@ -28,8 +28,7 @@ let args () =
     {
       arg_clean_tests_dir = true ;
       arg_max_jobs = 16 ;
-      arg_auto_promote = 0 ;
-      arg_fake = false ;
+      arg_ignore_exitcode = false;
       arg_print_results = false ;
       arg_subst_env = StringMap.empty ;
       arg_stop_on_first_failure = false ;
@@ -67,15 +66,9 @@ let args () =
     [ "no-clean" ], Arg.Unit (fun () -> args.arg_clean_tests_dir <- false),
     EZCMD.info "Do not clean _autofonce/ dir on startup";
 
-    (* This option is not useful I think, and causes a failure in
-       'autofonce rst' because it creates two "--diff" options for
-       'autofonce promote'
-
-    [ "diff" ], Arg.Unit (fun () ->
-        args.arg_auto_promote <- 1),
-      EZCMD.info "Print a diff showing what would be promoted";
-*)
-
+    [ "ignore-exitcode" ], Arg.Unit (fun () -> args.arg_ignore_exitcode <- true),
+    EZCMD.info "Do not promote or fail for wrong exit code" ;
+    
     [ "o" ; "output" ], Arg.String (fun s -> args.arg_output <- Some s),
     EZCMD.info
       ~env:(EZCMD.env "AUTOFONCE_OUTPUT")

--- a/src/autofonce_lib/types.ml
+++ b/src/autofonce_lib/types.ml
@@ -19,9 +19,7 @@ include Autofonce_config.Types
 type exec_args = {
   mutable arg_clean_tests_dir : bool ;
   mutable arg_max_jobs : int ;
-  mutable arg_auto_promote : int ;
-
-  mutable arg_fake : bool ;
+  mutable arg_ignore_exitcode : bool ;
   mutable arg_print_results : bool ;
   mutable arg_subst_env : ( string * string ) option StringMap.t ;
   mutable arg_stop_on_first_failure : bool ;


### PR DESCRIPTION
Most notably rename
- `run --auto-promote=n` into `promote --nb-promotions=n` where --nb-promotions defaults to 10
- `promote` into `diff`
- `--not-exit` into `--ignore-exitcode`

The new `promote` fixes a bug to avoid running the failing tests twice per promotion.