### PR TITLE
Improve Windows support

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-2390d875eacebdc281bba7aba60ccdfd:.
+e52de0ba6f4bbf9a101f085ab40cce84:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -110,57 +110,57 @@ e7379cf9741bb1cd7e4192973c166a04:drom.toml
 
 # begin context for dune-project
 # file dune-project
-3284dcf6826bd64dbbe1502aa625727a:dune-project
+0604a7b18644ef2a90953b602d8d16ff:dune-project
 # end context for dune-project
 
 # begin context for opam/autofonce.opam
 # file opam/autofonce.opam
-ab25928d14d6d59db653cbbc3d976f71:opam/autofonce.opam
+1e788872077577ad530ea98aa279d757:opam/autofonce.opam
 # end context for opam/autofonce.opam
 
 # begin context for opam/autofonce_config.opam
 # file opam/autofonce_config.opam
-c670127269deb01fdd50976776bf2636:opam/autofonce_config.opam
+beb338201942f01aa47dfb20c88db0e5:opam/autofonce_config.opam
 # end context for opam/autofonce_config.opam
 
 # begin context for opam/autofonce_core.opam
 # file opam/autofonce_core.opam
-c184d15d1dd010e3af6b4cc2d07f6ba1:opam/autofonce_core.opam
+36aa3621e039be7c96b1cd35166c8677:opam/autofonce_core.opam
 # end context for opam/autofonce_core.opam
 
 # begin context for opam/autofonce_lib.opam
 # file opam/autofonce_lib.opam
-3940d2808f5d6f11656719531af7af5c:opam/autofonce_lib.opam
+80dae21b3102443969b526366f15b2df:opam/autofonce_lib.opam
 # end context for opam/autofonce_lib.opam
 
 # begin context for opam/autofonce_m4.opam
 # file opam/autofonce_m4.opam
-499823712c72b1dbf7fe152595f10520:opam/autofonce_m4.opam
+42a0b39e233a4fe66b1e8fd4bb1e3cfc:opam/autofonce_m4.opam
 # end context for opam/autofonce_m4.opam
 
 # begin context for opam/autofonce_misc.opam
 # file opam/autofonce_misc.opam
-d76bf48ffd97f0d4c3be7235f09ecddb:opam/autofonce_misc.opam
+fbff990abb93dea0771964bcce6dd6f4:opam/autofonce_misc.opam
 # end context for opam/autofonce_misc.opam
 
 # begin context for opam/autofonce_patch.opam
 # file opam/autofonce_patch.opam
-19c93b8695f58e37459fb75631c7f4af:opam/autofonce_patch.opam
+9c30582781e70280b3e250bfca7b5e1f:opam/autofonce_patch.opam
 # end context for opam/autofonce_patch.opam
 
 # begin context for opam/autofonce_share.opam
 # file opam/autofonce_share.opam
-a507be92577a6266688dc86814b6f894:opam/autofonce_share.opam
+6fd0f88d2ba759238ccfbc3e13f95c7d:opam/autofonce_share.opam
 # end context for opam/autofonce_share.opam
 
 # begin context for opam/ez_call.opam
 # file opam/ez_call.opam
-dde037bcd171b218010afd57f9c6e966:opam/ez_call.opam
+2f397108dfb190bd5c95085d76181e5e:opam/ez_call.opam
 # end context for opam/ez_call.opam
 
 # begin context for opam/ez_win32.opam
 # file opam/ez_win32.opam
-34adb1412e9df5f995e71bd6b2d9fe88:opam/ez_win32.opam
+a22f3c6dbfe054130fa287025ebfd03b:opam/ez_win32.opam
 # end context for opam/ez_win32.opam
 
 # begin context for scripts/after.sh

--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-e52de0ba6f4bbf9a101f085ab40cce84:.
+841e453345a88541c858fbc9d22ade48:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -110,7 +110,7 @@ e7379cf9741bb1cd7e4192973c166a04:drom.toml
 
 # begin context for dune-project
 # file dune-project
-0604a7b18644ef2a90953b602d8d16ff:dune-project
+c5dc562fc2ab5d376342c413b9b53f9d:dune-project
 # end context for dune-project
 
 # begin context for opam/autofonce.opam
@@ -120,7 +120,7 @@ e7379cf9741bb1cd7e4192973c166a04:drom.toml
 
 # begin context for opam/autofonce_config.opam
 # file opam/autofonce_config.opam
-beb338201942f01aa47dfb20c88db0e5:opam/autofonce_config.opam
+fc611def0483ea8523478cb585da5eeb:opam/autofonce_config.opam
 # end context for opam/autofonce_config.opam
 
 # begin context for opam/autofonce_core.opam
@@ -140,12 +140,12 @@ beb338201942f01aa47dfb20c88db0e5:opam/autofonce_config.opam
 
 # begin context for opam/autofonce_misc.opam
 # file opam/autofonce_misc.opam
-fbff990abb93dea0771964bcce6dd6f4:opam/autofonce_misc.opam
+7759551cc48fc6e1f70a8528ab40d86f:opam/autofonce_misc.opam
 # end context for opam/autofonce_misc.opam
 
 # begin context for opam/autofonce_patch.opam
 # file opam/autofonce_patch.opam
-9c30582781e70280b3e250bfca7b5e1f:opam/autofonce_patch.opam
+08b0c9ce406db005c2d43a5e2746c256:opam/autofonce_patch.opam
 # end context for opam/autofonce_patch.opam
 
 # begin context for opam/autofonce_share.opam

--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-fb21a3973092788cdaea53aa9b29f866:.
+04c786a5eccd6389b33e8ab34ad45066:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -110,7 +110,7 @@ e7379cf9741bb1cd7e4192973c166a04:drom.toml
 
 # begin context for dune-project
 # file dune-project
-9c140374a39e057f810003d1330af170:dune-project
+554f2619d49ac1946c64fd59973212a9:dune-project
 # end context for dune-project
 
 # begin context for opam/autofonce.opam
@@ -130,7 +130,7 @@ c184d15d1dd010e3af6b4cc2d07f6ba1:opam/autofonce_core.opam
 
 # begin context for opam/autofonce_lib.opam
 # file opam/autofonce_lib.opam
-6d2b005a279a96bec81fb147b915d4de:opam/autofonce_lib.opam
+99d4d8d5b36ac2d5f9e4fea0036ee5f7:opam/autofonce_lib.opam
 # end context for opam/autofonce_lib.opam
 
 # begin context for opam/autofonce_m4.opam

--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-04c786a5eccd6389b33e8ab34ad45066:.
+2390d875eacebdc281bba7aba60ccdfd:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -110,7 +110,7 @@ e7379cf9741bb1cd7e4192973c166a04:drom.toml
 
 # begin context for dune-project
 # file dune-project
-554f2619d49ac1946c64fd59973212a9:dune-project
+3284dcf6826bd64dbbe1502aa625727a:dune-project
 # end context for dune-project
 
 # begin context for opam/autofonce.opam
@@ -130,7 +130,7 @@ c184d15d1dd010e3af6b4cc2d07f6ba1:opam/autofonce_core.opam
 
 # begin context for opam/autofonce_lib.opam
 # file opam/autofonce_lib.opam
-99d4d8d5b36ac2d5f9e4fea0036ee5f7:opam/autofonce_lib.opam
+3940d2808f5d6f11656719531af7af5c:opam/autofonce_lib.opam
 # end context for opam/autofonce_lib.opam
 
 # begin context for opam/autofonce_m4.opam
@@ -145,7 +145,7 @@ d76bf48ffd97f0d4c3be7235f09ecddb:opam/autofonce_misc.opam
 
 # begin context for opam/autofonce_patch.opam
 # file opam/autofonce_patch.opam
-46eaaccf5c08787cf6af78c9c85ef21d:opam/autofonce_patch.opam
+19c93b8695f58e37459fb75631c7f4af:opam/autofonce_patch.opam
 # end context for opam/autofonce_patch.opam
 
 # begin context for opam/autofonce_share.opam
@@ -350,7 +350,7 @@ fe7ce04bc869b44dfa07a44426083575:src/autofonce_misc/dune
 
 # begin context for src/autofonce_patch/dune
 # file src/autofonce_patch/dune
-45b284a2b6c2664853a175c7204eda82:src/autofonce_patch/dune
+8f2b4a1a9b2f8ddf67a589d1ba3c8ffc:src/autofonce_patch/dune
 # end context for src/autofonce_patch/dune
 
 # begin context for src/autofonce_patch/index.mld

--- a/drom.toml
+++ b/drom.toml
@@ -41,8 +41,6 @@ skip = ["@test", "tests", "CHANGES.md", ".github/workflows/workflow.yml", "sphin
 [dependencies]
 
 # project-wide tools dependencies (not for package-specific deps)
-[tools.ocamlformat]
-for-test = true
 [tools.odoc]
 for-doc = true
 [tools.ppx_expect]

--- a/dune-project
+++ b/dune-project
@@ -125,7 +125,7 @@
  (depends
    (ocaml (>= 4.10.0))
    (ocplib_stuff ( >= 0.1 ))
-   (ez_file ( >= 0.3 ))
+   (ez_file ( >= 0.5 ))
    (autofonce_misc (= :version))
    ppx_inline_test
    ppx_expect
@@ -146,7 +146,7 @@
    (ocaml (>= 4.10.0))
    (toml ( >= 7.0 ))
    (ocplib_stuff ( >= 0.1 ))
-   (ez_file ( >= 0.3 ))
+   (ez_file ( >= 0.5 ))
    (autofonce_misc (= :version))
    ppx_inline_test
    ppx_expect
@@ -166,7 +166,7 @@
  (depends
    (ocaml (>= 4.10.0))
    (ocplib_stuff ( >= 0.1 ))
-   (ez_file ( >= 0.3 ))
+   (ez_file ( >= 0.4 ))
    ppx_inline_test
    ppx_expect
    odoc

--- a/dune-project
+++ b/dune-project
@@ -62,7 +62,7 @@
  (depends
    (ocaml (>= 4.10.0))
    (ocplib_stuff ( >= 0.1 ))
-   (ez_file ( >= 0.3 ))
+   (ez_file ( >= 0.4 ))
    (ez_cmdliner ( >= 0.4.3 ))
    (ez_call ( >= 0.1 ))
    (autofonce_share (= :version))

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -46,7 +45,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -74,7 +72,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -95,7 +92,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -114,7 +110,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -135,7 +130,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -157,7 +151,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -177,7 +170,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -196,7 +188,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 
@@ -216,7 +207,6 @@
    ppx_inline_test
    ppx_expect
    odoc
-   ocamlformat
   )
  )
 

--- a/dune-project
+++ b/dune-project
@@ -62,7 +62,7 @@
  (depends
    (ocaml (>= 4.10.0))
    (ocplib_stuff ( >= 0.1 ))
-   (ez_file ( >= 0.4 ))
+   (ez_file ( >= 0.5 ))
    (ez_cmdliner ( >= 0.4.3 ))
    (ez_call ( >= 0.1 ))
    (autofonce_share (= :version))
@@ -131,6 +131,7 @@
    (ocaml (>= 4.10.0))
    (ocplib_stuff ( >= 0.1 ))
    (ez_file ( >= 0.3 ))
+   (autofonce_misc (= :version))
    ppx_inline_test
    ppx_expect
    odoc

--- a/opam/autofonce.opam
+++ b/opam/autofonce.opam
@@ -44,6 +44,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_config.opam
+++ b/opam/autofonce_config.opam
@@ -42,7 +42,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "toml" {>= "7.0"}
   "ocplib_stuff" {>= "0.1"}
-  "ez_file" {>= "0.3"}
+  "ez_file" {>= "0.5"}
   "autofonce_misc" {= version}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}

--- a/opam/autofonce_config.opam
+++ b/opam/autofonce_config.opam
@@ -47,6 +47,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_core.opam
+++ b/opam/autofonce_core.opam
@@ -49,6 +49,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_lib.opam
+++ b/opam/autofonce_lib.opam
@@ -41,7 +41,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.8.0"}
   "ocplib_stuff" {>= "0.1"}
-  "ez_file" {>= "0.3"}
+  "ez_file" {>= "0.4"}
   "ez_cmdliner" {>= "0.4.3"}
   "ez_call" {>= "0.1"}
   "autofonce_share" {= version}

--- a/opam/autofonce_lib.opam
+++ b/opam/autofonce_lib.opam
@@ -53,6 +53,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_lib.opam
+++ b/opam/autofonce_lib.opam
@@ -41,7 +41,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.8.0"}
   "ocplib_stuff" {>= "0.1"}
-  "ez_file" {>= "0.4"}
+  "ez_file" {>= "0.5"}
   "ez_cmdliner" {>= "0.4.3"}
   "ez_call" {>= "0.1"}
   "autofonce_share" {= version}

--- a/opam/autofonce_m4.opam
+++ b/opam/autofonce_m4.opam
@@ -46,6 +46,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_misc.opam
+++ b/opam/autofonce_misc.opam
@@ -45,6 +45,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_misc.opam
+++ b/opam/autofonce_misc.opam
@@ -41,7 +41,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.8.0"}
   "ocplib_stuff" {>= "0.1"}
-  "ez_file" {>= "0.3"}
+  "ez_file" {>= "0.4"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}

--- a/opam/autofonce_patch.opam
+++ b/opam/autofonce_patch.opam
@@ -42,6 +42,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ocplib_stuff" {>= "0.1"}
   "ez_file" {>= "0.3"}
+  "autofonce_misc" {= version}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}

--- a/opam/autofonce_patch.opam
+++ b/opam/autofonce_patch.opam
@@ -46,6 +46,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/autofonce_patch.opam
+++ b/opam/autofonce_patch.opam
@@ -41,7 +41,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.8.0"}
   "ocplib_stuff" {>= "0.1"}
-  "ez_file" {>= "0.3"}
+  "ez_file" {>= "0.5"}
   "autofonce_misc" {= version}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}

--- a/opam/autofonce_share.opam
+++ b/opam/autofonce_share.opam
@@ -44,6 +44,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/ez_call.opam
+++ b/opam/ez_call.opam
@@ -45,6 +45,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/opam/ez_win32.opam
+++ b/opam/ez_win32.opam
@@ -44,6 +44,5 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}
-  "ocamlformat" {with-test}
 ]
 # Content of `opam-trailer` field:

--- a/src/autofonce_config/package.toml
+++ b/src/autofonce_config/package.toml
@@ -47,7 +47,7 @@ skip = ["main.ml"]
 #   base-unix = { libname = "unix", version = ">=base" } 
 [dependencies]
 autofonce_misc = "version"
-ez_file = ">=0.3"
+ez_file = ">=0.5"
 ocplib_stuff = ">=0.1"
 toml = ">=7.0"
 

--- a/src/autofonce_config/project_config.ml
+++ b/src/autofonce_config/project_config.ml
@@ -133,7 +133,7 @@ let parse_table
                  let file = String.sub env_value 1 (len-1) in
                  let filename = project_source_dir // file in
                  let env_content = try
-                     Misc.read_file filename
+                     EzFile.read_text_file filename
                    with _ ->
                      Misc.error "envs.%s references unexistent file %s"
                        env_name file
@@ -352,4 +352,4 @@ let to_string p =
   Buffer.contents b
 
 let to_file p =
-  Misc.write_file p.project_file ( to_string p )
+  EzFile.write_text_file p.project_file ( to_string p )

--- a/src/autofonce_config/project_config.ml
+++ b/src/autofonce_config/project_config.ml
@@ -27,7 +27,7 @@ let get_string ~prefix ~file table suffix =
 
 let find_dir_by_anchor ?cwd anchors =
   let cwd = match cwd with
-    | None -> Sys.getcwd ()
+    | None -> Misc.getcwd ()
     | Some cwd -> cwd in
 
   let rec iter anchors =
@@ -113,7 +113,7 @@ let parse_table
               | dir -> dir
         in
         iter ~fail:false
-          ( Sys.getcwd () ::
+          ( Misc.getcwd () ::
             (List.map (fun s -> project_source_dir // s) project_build_dir_candidates))
   in
   let project_envs =
@@ -133,7 +133,7 @@ let parse_table
                  let file = String.sub env_value 1 (len-1) in
                  let filename = project_source_dir // file in
                  let env_content = try
-                     EzFile.read_file filename
+                     Misc.read_file filename
                    with _ ->
                      Misc.error "envs.%s references unexistent file %s"
                        env_name file
@@ -352,4 +352,4 @@ let to_string p =
   Buffer.contents b
 
 let to_file p =
-  EzFile.write_file p.project_file ( to_string p )
+  Misc.write_file p.project_file ( to_string p )

--- a/src/autofonce_lib/command_gen.ml
+++ b/src/autofonce_lib/command_gen.ml
@@ -72,7 +72,7 @@ let cmd =
 
        let files = List.map (fun file ->
            let basename = Filename.basename file in
-           let content = EzFile.read_file file in
+           let content = Misc.read_file file in
            EzFile.write_file (Filename.concat files_dir basename) content;
            basename
          ) !files
@@ -80,7 +80,7 @@ let cmd =
 
        let data = List.map (fun file ->
            let basename = Filename.basename file in
-           let content = EzFile.read_file file in
+           let content = Misc.read_file file in
            EzFile.write_file (Filename.concat shared_dir basename) content;
            basename
          ) (List.rev !data)

--- a/src/autofonce_lib/command_gen.ml
+++ b/src/autofonce_lib/command_gen.ml
@@ -72,7 +72,7 @@ let cmd =
 
        let files = List.map (fun file ->
            let basename = Filename.basename file in
-           let content = Misc.read_file file in
+           let content = EzFile.read_text_file file in
            EzFile.write_file (Filename.concat files_dir basename) content;
            basename
          ) !files
@@ -80,7 +80,7 @@ let cmd =
 
        let data = List.map (fun file ->
            let basename = Filename.basename file in
-           let content = Misc.read_file file in
+           let content = EzFile.read_text_file file in
            EzFile.write_file (Filename.concat shared_dir basename) content;
            basename
          ) (List.rev !data)

--- a/src/autofonce_lib/command_new.ml
+++ b/src/autofonce_lib/command_new.ml
@@ -13,7 +13,6 @@
 open Ez_win32.V1
 open Ezcmd.V2
 open EZCMD.TYPES
-open Ez_file.V1
 open Ez_call.V1
 
 module Misc = Autofonce_misc.Misc
@@ -52,7 +51,7 @@ let cmd =
     (fun () ->
 
        let files = List.map (fun file ->
-           let content = EzFile.read_file file in
+           let content = Misc.read_file file in
            (file, content)
          ) !files
        in
@@ -66,8 +65,8 @@ let cmd =
        let stderr = EzCall.tmpfile () in
        let pid = EzCall.create_process ~stdout ~stderr command in
        let retcode = Unix.uninterrupted_waitpid pid in
-       let stdout_content = EzFile.read_file stdout in
-       let stderr_content = EzFile.read_file stderr in
+       let stdout_content = Misc.read_file stdout in
+       let stderr_content = Misc.read_file stderr in
        Sys.remove stdout;
        Sys.remove stderr;
        let b = Buffer.create 10000 in
@@ -117,7 +116,7 @@ let cmd =
        match !output with
        | None -> Printf.printf "%s%!" s
        | Some file ->
-           EzFile.write_file file s
+           Misc.write_file file s
     )
     ~args
     ~doc: "Create a new test by running a command"

--- a/src/autofonce_lib/command_new.ml
+++ b/src/autofonce_lib/command_new.ml
@@ -13,6 +13,7 @@
 open Ez_win32.V1
 open Ezcmd.V2
 open EZCMD.TYPES
+open Ez_file.V1
 open Ez_call.V1
 
 module Misc = Autofonce_misc.Misc
@@ -51,7 +52,7 @@ let cmd =
     (fun () ->
 
        let files = List.map (fun file ->
-           let content = Misc.read_file file in
+           let content = EzFile.read_text_file file in
            (file, content)
          ) !files
        in
@@ -65,8 +66,8 @@ let cmd =
        let stderr = EzCall.tmpfile () in
        let pid = EzCall.create_process ~stdout ~stderr command in
        let retcode = Unix.uninterrupted_waitpid pid in
-       let stdout_content = Misc.read_file stdout in
-       let stderr_content = Misc.read_file stderr in
+       let stdout_content = EzFile.read_text_file stdout in
+       let stderr_content = EzFile.read_text_file stderr in
        Sys.remove stdout;
        Sys.remove stderr;
        let b = Buffer.create 10000 in
@@ -116,7 +117,7 @@ let cmd =
        match !output with
        | None -> Printf.printf "%s%!" s
        | Some file ->
-           Misc.write_file file s
+           EzFile.write_text_file file s
     )
     ~args
     ~doc: "Create a new test by running a command"

--- a/src/autofonce_lib/logging.ml
+++ b/src/autofonce_lib/logging.ml
@@ -94,7 +94,7 @@ let log_checks ?failed_check state ter =
         let filename = check_dir // file in
         if Sys.file_exists filename then begin
           log_header ~indent:6 state "File %s" file;
-          match EzFile.read_file filename with
+          match MISC.read_file filename with
           | exception exn ->
               Printf.bprintf b "Exception while reading %S:\n  %s\n"
                 filename ( Printexc.to_string exn )
@@ -149,7 +149,7 @@ let log_captured_files ?indent ?dir state msg files =
   List.iter (fun file ->
       log_header ?indent state "%s: captured file %S" msg file ;
       let filename = dir // file in
-      match EzFile.read_file filename with
+      match MISC.read_file filename with
       | exception exn ->
           Printf.bprintf b "Exception while reading %S:\n  %s\n"
             filename ( Printexc.to_string exn )
@@ -190,7 +190,7 @@ let log_failed_tests state msg tests =
         t b1 t.test_actions ;
       let s1 = Buffer.contents b1 in
       let f1 = test_dir // "test.at.expected" in
-      EzFile.write_file f1 s1;
+      MISC.write_file f1 s1;
 
       Buffer.reset b2;
       Promote.print_actions
@@ -199,12 +199,12 @@ let log_failed_tests state msg tests =
         t b2 t.test_actions ;
       let s2 = Buffer.contents b2 in
       let f2 = test_dir // "test.at.promoted" in
-      EzFile.write_file f2 s2;
+      MISC.write_file f2 s2;
 
       let test_at_diff = test_dir // "test.at.diff" in
       MISC.command_ "diff -u %s %s > %s"
         f1 f2 test_at_diff ;
-      let diff = EzFile.read_file test_at_diff in
+      let diff = MISC.read_file test_at_diff in
 
       log_header ~indent:2 state "Expected test:";
       Printf.bprintf state.state_buffer "%s\n" s1;
@@ -239,9 +239,9 @@ let log_state_buffer state =
   let buffer_file = match state.state_args.arg_output with
     | None ->
         let tests_dir = Autofonce_config.Globals.tests_dir in
-        Sys.getcwd () // tests_dir // "results.log"
+        MISC.getcwd () // tests_dir // "results.log"
     | Some output -> output
   in
   let buffer = Buffer.contents state.state_buffer in
-  EzFile.write_file buffer_file buffer;
+  MISC.write_file buffer_file buffer;
   Printf.eprintf "File %S created with failure results\n%!" buffer_file;

--- a/src/autofonce_lib/logging.ml
+++ b/src/autofonce_lib/logging.ml
@@ -94,7 +94,7 @@ let log_checks ?failed_check state ter =
         let filename = check_dir // file in
         if Sys.file_exists filename then begin
           log_header ~indent:6 state "File %s" file;
-          match MISC.read_file filename with
+          match EzFile.read_text_file filename with
           | exception exn ->
               Printf.bprintf b "Exception while reading %S:\n  %s\n"
                 filename ( Printexc.to_string exn )
@@ -149,7 +149,7 @@ let log_captured_files ?indent ?dir state msg files =
   List.iter (fun file ->
       log_header ?indent state "%s: captured file %S" msg file ;
       let filename = dir // file in
-      match MISC.read_file filename with
+      match EzFile.read_text_file filename with
       | exception exn ->
           Printf.bprintf b "Exception while reading %S:\n  %s\n"
             filename ( Printexc.to_string exn )
@@ -190,7 +190,7 @@ let log_failed_tests state msg tests =
         t b1 t.test_actions ;
       let s1 = Buffer.contents b1 in
       let f1 = test_dir // "test.at.expected" in
-      MISC.write_file f1 s1;
+      EzFile.write_text_file f1 s1;
 
       Buffer.reset b2;
       Promote.print_actions
@@ -199,12 +199,12 @@ let log_failed_tests state msg tests =
         t b2 t.test_actions ;
       let s2 = Buffer.contents b2 in
       let f2 = test_dir // "test.at.promoted" in
-      MISC.write_file f2 s2;
+      EzFile.write_text_file f2 s2;
 
       let test_at_diff = test_dir // "test.at.diff" in
       MISC.command_ "diff -u %s %s > %s"
         f1 f2 test_at_diff ;
-      let diff = MISC.read_file test_at_diff in
+      let diff = EzFile.read_text_file test_at_diff in
 
       log_header ~indent:2 state "Expected test:";
       Printf.bprintf state.state_buffer "%s\n" s1;
@@ -243,5 +243,5 @@ let log_state_buffer state =
     | Some output -> output
   in
   let buffer = Buffer.contents state.state_buffer in
-  MISC.write_file buffer_file buffer;
+  EzFile.write_text_file buffer_file buffer;
   Printf.eprintf "File %S created with failure results\n%!" buffer_file;

--- a/src/autofonce_lib/main.ml
+++ b/src/autofonce_lib/main.ml
@@ -12,6 +12,7 @@
 
 open Ezcmd.V2
 open Ez_call.V1
+open Ez_file.V1
 
 module Misc = Autofonce_misc.Misc
 
@@ -50,8 +51,9 @@ let commands = [
 
 let main () =
 
+  Slashifier.enable ();
   begin
-    try ignore ( Sys.getcwd () )
+    try ignore ( Misc.getcwd () )
     with _ ->
       Printf.eprintf "Current directory does not exist anymore. Move back up.\n%!";
       exit 2

--- a/src/autofonce_lib/package.toml
+++ b/src/autofonce_lib/package.toml
@@ -53,7 +53,7 @@ autofonce_m4 = "version"
 autofonce_patch = "version"
 autofonce_share = "version"
 ez_cmdliner = ">=0.4.3"
-ez_file = ">=0.4"
+ez_file = ">=0.5"
 ocplib_stuff = ">=0.1"
 ez_call = "0.1"
 

--- a/src/autofonce_lib/package.toml
+++ b/src/autofonce_lib/package.toml
@@ -53,7 +53,7 @@ autofonce_m4 = "version"
 autofonce_patch = "version"
 autofonce_share = "version"
 ez_cmdliner = ">=0.4.3"
-ez_file = ">=0.3"
+ez_file = ">=0.4"
 ocplib_stuff = ">=0.1"
 ez_call = "0.1"
 

--- a/src/autofonce_lib/promote.ml
+++ b/src/autofonce_lib/promote.ml
@@ -54,7 +54,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
           | Some old_retcode ->
               let check_exit = Printf.sprintf "%s.exit" check_prefix in
               if Sys.file_exists check_exit then
-                let s = EzFile.read_file check_exit in
+                let s = Misc.read_file check_exit in
                 let retcode = int_of_string s in
                 Some retcode
               else
@@ -69,7 +69,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
               let check_stdout =
                 Printf.sprintf "%s.out.subst" check_prefix in
               if Sys.file_exists check_stdout then
-                let s = EzFile.read_file check_stdout in
+                let s = Misc.read_file check_stdout in
                 Content s
               else
                 Content old_content
@@ -86,7 +86,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
               let check_stderr =
                 Printf.sprintf "%s.err.subst" check_prefix in
               if Sys.file_exists check_stderr then
-                let s = EzFile.read_file check_stderr in
+                let s = Misc.read_file check_stderr in
                 Content s
               else
                 Content old_content
@@ -254,7 +254,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
           | None -> content
           | Some filename ->
               let dirname = Filename.dirname t.test_loc.file in
-              EzFile.read_file (Filename.concat dirname filename)
+              Misc.read_file (Filename.concat dirname filename)
         in
         print_action b (AF_COMMENT comment);
         print_action b (AT_DATA { file ; content });

--- a/src/autofonce_lib/promote.ml
+++ b/src/autofonce_lib/promote.ml
@@ -16,7 +16,6 @@ open EzFile.OP
 
 module Patch_lines = Autofonce_patch.Patch_lines
 module Parser = Autofonce_core.Parser
-module Misc = Autofonce_misc.Misc
 open Types
 
 (* TODO: Currently, we don't handle the use of `expout` and `experr`
@@ -54,7 +53,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
           | Some old_retcode ->
               let check_exit = Printf.sprintf "%s.exit" check_prefix in
               if Sys.file_exists check_exit then
-                let s = Misc.read_file check_exit in
+                let s = EzFile.read_text_file check_exit in
                 let retcode = int_of_string s in
                 Some retcode
               else
@@ -69,7 +68,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
               let check_stdout =
                 Printf.sprintf "%s.out.subst" check_prefix in
               if Sys.file_exists check_stdout then
-                let s = Misc.read_file check_stdout in
+                let s = EzFile.read_text_file check_stdout in
                 Content s
               else
                 Content old_content
@@ -86,7 +85,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
               let check_stderr =
                 Printf.sprintf "%s.err.subst" check_prefix in
               if Sys.file_exists check_stderr then
-                let s = Misc.read_file check_stderr in
+                let s = EzFile.read_text_file check_stderr in
                 Content s
               else
                 Content old_content
@@ -254,7 +253,7 @@ let print_actions t ~ignore_exitcode ~keep_old b actions =
           | None -> content
           | Some filename ->
               let dirname = Filename.dirname t.test_loc.file in
-              Misc.read_file (Filename.concat dirname filename)
+              EzFile.read_text_file (Filename.concat dirname filename)
         in
         print_action b (AF_COMMENT comment);
         print_action b (AT_DATA { file ; content });

--- a/src/autofonce_lib/runner_common.ml
+++ b/src/autofonce_lib/runner_common.ml
@@ -179,7 +179,7 @@ let test_is_skip ter =
 let exec_action_no_check ter action =
   match action with
   | AT_DATA { file ; content } ->
-      EzFile.write_file ( tester_dir ter // file ) content
+      MISC.write_file ( tester_dir ter // file ) content
   | AT_CLEANUP _ -> ()
   | AF_COMMENT _ -> ()
   | AT_XFAIL -> ter.tester_fail_expected <- true
@@ -302,7 +302,7 @@ let start_test state t =
   else
     Unix.mkdir test_dir 0o755;
 
-  EzFile.write_file ( test_dir // Autofonce_config.Globals.env_autofonce_sh ) @@
+  MISC.write_file ( test_dir // Autofonce_config.Globals.env_autofonce_sh ) @@
   Printf.sprintf {|#!/bin/sh
 # name of testsuite in 'autofonce.toml'
 AUTOFONCE_TESTSUITE="%s"
@@ -359,7 +359,7 @@ let start_check ter check =
       check.check_command
   in
   let test_dir = tester_dir ter in
-  EzFile.write_file ( test_dir // check_sh ) check_content ;
+  MISC.write_file ( test_dir // check_sh ) check_content ;
   Unix.chmod (test_dir // check_sh ) 0o755 ;
   Unix.chdir test_dir ;
   let checker_pid = EzCall.create_process_for_shell
@@ -394,7 +394,7 @@ let subst_env state var =
       pair
 
 let read_subst_output ter file =
-  let s = EzFile.read_file file in
+  let s = MISC.read_file file in
   let t = ter.tester_test in
   let state = ter.tester_state in
   List.fold_left (fun s var ->
@@ -436,9 +436,9 @@ let check_failures cer retcode =
         let subst_stdout = read_subst_output ter stdout_file in
         if subst_stdout <> expected then begin
           let stdout_expected_file = stdout_file ^ ".expected" in
-          EzFile.write_file stdout_expected_file expected ;
+          MISC.write_file stdout_expected_file expected ;
           let stdout_subst_file = stdout_file ^ ".subst" in
-          EzFile.write_file stdout_subst_file subst_stdout ;
+          MISC.write_file stdout_subst_file subst_stdout ;
           MISC.command_ "diff -u %s %s > %s.diff"
             stdout_subst_file stdout_expected_file stdout_file;
           [ kind ]
@@ -446,17 +446,18 @@ let check_failures cer retcode =
     | Save_to_file target ->
         let stdout_file = test_dir // file in
         let target_file = test_dir // target in
-        let content = EzFile.read_file stdout_file in
-        EzFile.write_file target_file content;
+        let content = MISC.read_file stdout_file in
+        MISC.write_file target_file content;
         []
     | Diff_with_file expected ->
         let stdout_file = test_dir // file in
-        let stdout_content = EzFile.read_file stdout_file in
+        let stdout_content = MISC.read_file stdout_file in
         let expected_file = test_dir // expected in
-        let expected_content = EzFile.read_file expected_file in
+        let expected_content = MISC.read_file expected_file in
         if expected_content <> stdout_content then begin
+          assert (if true then false else false);
           let stdout_expected_file = stdout_file ^ ".expected" in
-          EzFile.write_file stdout_expected_file expected_content ;
+          MISC.write_file stdout_expected_file expected_content ;
           MISC.command_ "diff -u %s %s > %s.diff"
             stdout_file stdout_expected_file stdout_file;
           [ kind ]
@@ -469,8 +470,8 @@ let check_failures cer retcode =
         if retcode <> expected then begin
           let check_exit = Printf.sprintf "%s.exit" check_prefix in
           let check_exit = test_dir // check_exit in
-          EzFile.write_file check_exit (string_of_int retcode);
-          EzFile.write_file (check_exit ^ ".expected")
+          MISC.write_file check_exit (string_of_int retcode);
+          MISC.write_file (check_exit ^ ".expected")
             (string_of_int expected);
           [ "exitcode" ]
         end else []

--- a/src/autofonce_lib/runner_common.ml
+++ b/src/autofonce_lib/runner_common.ml
@@ -68,7 +68,7 @@ let args () =
 
     [ "ignore-exitcode" ], Arg.Unit (fun () -> args.arg_ignore_exitcode <- true),
     EZCMD.info "Do not promote or fail for wrong exit code" ;
-    
+
     [ "o" ; "output" ], Arg.String (fun s -> args.arg_output <- Some s),
     EZCMD.info
       ~env:(EZCMD.env "AUTOFONCE_OUTPUT")
@@ -179,7 +179,7 @@ let test_is_skip ter =
 let exec_action_no_check ter action =
   match action with
   | AT_DATA { file ; content } ->
-      MISC.write_file ( tester_dir ter // file ) content
+      EzFile.write_text_file ( tester_dir ter // file ) content
   | AT_CLEANUP _ -> ()
   | AF_COMMENT _ -> ()
   | AT_XFAIL -> ter.tester_fail_expected <- true
@@ -302,7 +302,7 @@ let start_test state t =
   else
     Unix.mkdir test_dir 0o755;
 
-  MISC.write_file ( test_dir // Autofonce_config.Globals.env_autofonce_sh ) @@
+  EzFile.write_text_file ( test_dir // Autofonce_config.Globals.env_autofonce_sh ) @@
   Printf.sprintf {|#!/bin/sh
 # name of testsuite in 'autofonce.toml'
 AUTOFONCE_TESTSUITE="%s"
@@ -359,7 +359,7 @@ let start_check ter check =
       check.check_command
   in
   let test_dir = tester_dir ter in
-  MISC.write_file ( test_dir // check_sh ) check_content ;
+  EzFile.write_text_file ( test_dir // check_sh ) check_content ;
   Unix.chmod (test_dir // check_sh ) 0o755 ;
   Unix.chdir test_dir ;
   let checker_pid = EzCall.create_process_for_shell
@@ -394,7 +394,7 @@ let subst_env state var =
       pair
 
 let read_subst_output ter file =
-  let s = MISC.read_file file in
+  let s = EzFile.read_text_file file in
   let t = ter.tester_test in
   let state = ter.tester_state in
   List.fold_left (fun s var ->
@@ -436,9 +436,9 @@ let check_failures cer retcode =
         let subst_stdout = read_subst_output ter stdout_file in
         if subst_stdout <> expected then begin
           let stdout_expected_file = stdout_file ^ ".expected" in
-          MISC.write_file stdout_expected_file expected ;
+          EzFile.write_text_file stdout_expected_file expected ;
           let stdout_subst_file = stdout_file ^ ".subst" in
-          MISC.write_file stdout_subst_file subst_stdout ;
+          EzFile.write_text_file stdout_subst_file subst_stdout ;
           MISC.command_ "diff -u %s %s > %s.diff"
             stdout_subst_file stdout_expected_file stdout_file;
           [ kind ]
@@ -446,18 +446,18 @@ let check_failures cer retcode =
     | Save_to_file target ->
         let stdout_file = test_dir // file in
         let target_file = test_dir // target in
-        let content = MISC.read_file stdout_file in
-        MISC.write_file target_file content;
+        let content = EzFile.read_text_file stdout_file in
+        EzFile.write_text_file target_file content;
         []
     | Diff_with_file expected ->
         let stdout_file = test_dir // file in
-        let stdout_content = MISC.read_file stdout_file in
+        let stdout_content = EzFile.read_text_file stdout_file in
         let expected_file = test_dir // expected in
-        let expected_content = MISC.read_file expected_file in
+        let expected_content = EzFile.read_text_file expected_file in
         if expected_content <> stdout_content then begin
           assert (if true then false else false);
           let stdout_expected_file = stdout_file ^ ".expected" in
-          MISC.write_file stdout_expected_file expected_content ;
+          EzFile.write_text_file stdout_expected_file expected_content ;
           MISC.command_ "diff -u %s %s > %s.diff"
             stdout_file stdout_expected_file stdout_file;
           [ kind ]
@@ -470,8 +470,8 @@ let check_failures cer retcode =
         if retcode <> expected then begin
           let check_exit = Printf.sprintf "%s.exit" check_prefix in
           let check_exit = test_dir // check_exit in
-          MISC.write_file check_exit (string_of_int retcode);
-          MISC.write_file (check_exit ^ ".expected")
+          EzFile.write_text_file check_exit (string_of_int retcode);
+          EzFile.write_text_file (check_exit ^ ".expected")
             (string_of_int expected);
           [ "exitcode" ]
         end else []

--- a/src/autofonce_lib/testsuite.ml
+++ b/src/autofonce_lib/testsuite.ml
@@ -92,7 +92,7 @@ let find args =
               {
                 env_name = "";
                 env_kind = Env_file testsuite_env ;
-                env_content = MISC.read_file testsuite_env ;
+                env_content = EzFile.read_text_file testsuite_env ;
               }
         in
         let config_name = match args.arg_testsuite with

--- a/src/autofonce_lib/testsuite.ml
+++ b/src/autofonce_lib/testsuite.ml
@@ -63,7 +63,7 @@ let read p tc =
 let find args =
 
   begin
-    if not ( Sys.file_exists ( Sys.getcwd () )) then
+    if not ( Sys.file_exists ( MISC.getcwd () )) then
       MISC.error "Current directory does not exist anymore. Move back up.\n%!";
   end ;
 
@@ -92,7 +92,7 @@ let find args =
               {
                 env_name = "";
                 env_kind = Env_file testsuite_env ;
-                env_content = EzFile.read_file testsuite_env ;
+                env_content = MISC.read_file testsuite_env ;
               }
         in
         let config_name = match args.arg_testsuite with
@@ -149,11 +149,11 @@ let exec ~filter_args ~exec_args p tc suite =
 
   if not ( Sys.file_exists tests_dir ) then begin
     Runner_common.output state "Creating testing directory %s\n%!"
-      (Sys.getcwd () // tests_dir);
+      (MISC.getcwd () // tests_dir);
     Unix.mkdir tests_dir 0o755;
   end else begin
     Runner_common.output state "Using testing directory %s\n%!"
-      (Sys.getcwd () // tests_dir);
+      (MISC.getcwd () // tests_dir);
   end;
 
   if state.state_args.arg_max_jobs = 1 then

--- a/src/autofonce_misc/misc.ml
+++ b/src/autofonce_misc/misc.ml
@@ -39,6 +39,9 @@ let remove_rec dir = command "rm -rf %s" dir
 
 let remove_all dir = command "rm -rf %s/*" dir
 
+let getcwd () =
+  Slashifier.slashify @@ Sys.getcwd ()
+
 let find_file ?from file =
   let rec iter dirname =
     let filename = dirname // file in
@@ -50,7 +53,7 @@ let find_file ?from file =
         iter newdir
   in
   let from = match from with
-    | None -> Sys.getcwd ()
+    | None -> getcwd ()
     | Some dir -> dir
   in
   iter from
@@ -67,3 +70,27 @@ let find_in_path path name =
           else try_dir rem
     in
     try_dir path
+
+let with_open open_channel close_channel filename f =
+  let ic = open_channel filename in
+  try
+    let x = f ic in
+    close_channel ic;
+    x
+  with exn ->
+    close_channel ic;
+    raise exn
+
+let with_in filename f = with_open open_in close_in filename f
+
+let with_out filename f = with_open open_out close_out filename f
+
+let read_file filename =
+  if Sys.win32
+  then with_in filename FileChannel.read_file
+  else EzFile.read_file filename
+
+let write_file filename contents =
+  if Sys.win32
+  then with_out filename (fun oc -> FileChannel.write_file oc contents)
+  else EzFile.write_file filename contents

--- a/src/autofonce_misc/misc.ml
+++ b/src/autofonce_misc/misc.ml
@@ -71,26 +71,6 @@ let find_in_path path name =
     in
     try_dir path
 
-let with_open open_channel close_channel filename f =
-  let ic = open_channel filename in
-  try
-    let x = f ic in
-    close_channel ic;
-    x
-  with exn ->
-    close_channel ic;
-    raise exn
+let read_file = EzFile.read_text_file
 
-let with_in filename f = with_open open_in close_in filename f
-
-let with_out filename f = with_open open_out close_out filename f
-
-let read_file filename =
-  if Sys.win32
-  then with_in filename FileChannel.read_file
-  else EzFile.read_file filename
-
-let write_file filename contents =
-  if Sys.win32
-  then with_out filename (fun oc -> FileChannel.write_file oc contents)
-  else EzFile.write_file filename contents
+let write_file = EzFile.write_text_file

--- a/src/autofonce_misc/misc.ml
+++ b/src/autofonce_misc/misc.ml
@@ -70,7 +70,3 @@ let find_in_path path name =
           else try_dir rem
     in
     try_dir path
-
-let read_file = EzFile.read_text_file
-
-let write_file = EzFile.write_text_file

--- a/src/autofonce_misc/package.toml
+++ b/src/autofonce_misc/package.toml
@@ -46,7 +46,7 @@ skip = ["main.ml"]
 #   ez_file = ">=0.1 <1.3"
 #   base-unix = { libname = "unix", version = ">=base" } 
 [dependencies]
-ez_file = ">=0.3"
+ez_file = ">=0.4"
 ocplib_stuff = ">=0.1"
 
 # package tools dependencies

--- a/src/autofonce_patch/dune
+++ b/src/autofonce_patch/dune
@@ -5,7 +5,7 @@
   (public_name autofonce_patch)
   (wrapped true)
   ; use field 'dune-libraries' to add libraries without opam deps
-  (libraries ocplib_stuff ez_file )
+  (libraries ocplib_stuff ez_file autofonce_misc)
   ; use field 'dune-flags' to set this value
   (flags (:standard))
   ; use field 'dune-stanzas' to add more stanzas here

--- a/src/autofonce_patch/dune
+++ b/src/autofonce_patch/dune
@@ -5,7 +5,7 @@
   (public_name autofonce_patch)
   (wrapped true)
   ; use field 'dune-libraries' to add libraries without opam deps
-  (libraries ocplib_stuff ez_file autofonce_misc)
+  (libraries ocplib_stuff ez_file autofonce_misc )
   ; use field 'dune-flags' to set this value
   (flags (:standard))
   ; use field 'dune-stanzas' to add more stanzas here

--- a/src/autofonce_patch/package.toml
+++ b/src/autofonce_patch/package.toml
@@ -46,7 +46,7 @@ skip = ["main.ml"]
 #   ez_file = ">=0.1 <1.3"
 #   base-unix = { libname = "unix", version = ">=base" } 
 [dependencies]
-ez_file = ">=0.3"
+ez_file = ">=0.5"
 ocplib_stuff = ">=0.1"
 autofonce_misc = "version"
 

--- a/src/autofonce_patch/package.toml
+++ b/src/autofonce_patch/package.toml
@@ -48,6 +48,7 @@ skip = ["main.ml"]
 [dependencies]
 ez_file = ">=0.3"
 ocplib_stuff = ">=0.1"
+autofonce_misc = "version"
 
 # package tools dependencies
 [tools]

--- a/src/autofonce_patch/patch_lines.ml
+++ b/src/autofonce_patch/patch_lines.ml
@@ -13,6 +13,8 @@
 open Ez_file.V1
 open EzFile.OP
 
+module MISC = Autofonce_misc.Misc
+
 type action =
   | Apply (* really apply to file *)
   | Fake of string  (* generate files with EXTENSION instead of former
@@ -70,7 +72,7 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
   Sys.remove tmp_dir ;
   let tmp_dir_a = tmp_dir // "a" in
   let tmp_dir_b = tmp_dir // "b" in
-  let cwd = Sys.getcwd () in
+  let cwd = MISC.getcwd () in
   Hashtbl.iter (fun file actions ->
       let actions = List.sort compare_actions !actions in
       let inconsistent = check_consistency actions in
@@ -79,7 +81,7 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
           "Discarding inconsistent changes demanded on file %s\n%!"
           file
       else
-        let old_content = EzFile.read_file file in
+        let old_content = MISC.read_file file in
         let lines = EzString.split old_content '\n' in
         let new_lines = ref [] in
         let rec iter num lines actions =
@@ -119,11 +121,11 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
         match action with
         | Fake ext ->
             let file = file ^ ext in
-            EzFile.write_file file content;
+            MISC.write_file file content;
             Printf.eprintf "File %S updated\n%!" file
         | Apply ->
             let new_file = file ^ ".new" in
-            EzFile.write_file new_file content;
+            MISC.write_file new_file content;
             Sys.rename file (file ^ backup);
             Sys.rename new_file file;
             Printf.eprintf "File %S updated\n%!" file
@@ -137,8 +139,8 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
             let basename = Filename.basename file in
             let file_a = "a" // basename in
             let file_b = "b" // basename in
-            EzFile.write_file file_a old_content ;
-            EzFile.write_file file_b content ;
+            MISC.write_file file_a old_content ;
+            MISC.write_file file_b content ;
             let cmd = Printf.sprintf
                 "diff %s %s %s %s"
                 (match args with

--- a/src/autofonce_patch/patch_lines.ml
+++ b/src/autofonce_patch/patch_lines.ml
@@ -81,7 +81,7 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
           "Discarding inconsistent changes demanded on file %s\n%!"
           file
       else
-        let old_content = MISC.read_file file in
+        let old_content = EzFile.read_text_file file in
         let lines = EzString.split old_content '\n' in
         let new_lines = ref [] in
         let rec iter num lines actions =
@@ -121,11 +121,11 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
         match action with
         | Fake ext ->
             let file = file ^ ext in
-            MISC.write_file file content;
+            EzFile.write_text_file file content;
             Printf.eprintf "File %S updated\n%!" file
         | Apply ->
             let new_file = file ^ ".new" in
-            MISC.write_file new_file content;
+            EzFile.write_text_file new_file content;
             Sys.rename file (file ^ backup);
             Sys.rename new_file file;
             Printf.eprintf "File %S updated\n%!" file
@@ -139,8 +139,8 @@ let commit_to_disk ?(action=Diff { exclude=[]; args=None }) ?(backup="~") () =
             let basename = Filename.basename file in
             let file_a = "a" // basename in
             let file_b = "b" // basename in
-            MISC.write_file file_a old_content ;
-            MISC.write_file file_b content ;
+            EzFile.write_text_file file_a old_content ;
+            EzFile.write_text_file file_b content ;
             let cmd = Printf.sprintf
                 "diff %s %s %s %s"
                 (match args with


### PR DESCRIPTION
- Enforce use of slahes instead of backslashes in input file names, including on the result of `Sys.getcwd`
- Read input files as text instead of binary

Aside:
- Drop dependency on `ocamlformat`